### PR TITLE
[PR] Display long times as days+hours

### DIFF
--- a/SDVModTest/UIElements/ShowCropAndBarrelTime.cs
+++ b/SDVModTest/UIElements/ShowCropAndBarrelTime.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using UIInfoSuite.Extensions;
 using StardewModdingAPI.Events;
 using StardewValley;
@@ -159,16 +159,43 @@ namespace UIInfoSuite.UIElements
                     }
                     else
                     {
-                        int hours = _currentTile.MinutesUntilReady / 60;
-                        int minutes = _currentTile.MinutesUntilReady % 60;
-                        if (hours > 0)
-                            hoverText.Append(hours).Append(" ")
+                        int timeLeft = _currentTile.MinutesUntilReady;
+                        int longTime = timeLeft / 60;
+                        string longText = LanguageKeys.Hours;
+                        int shortTime = timeLeft % 60;
+                        string shortText = LanguageKeys.Minutes;
+
+                        // 1600 minutes per day if you go to bed at 2am, more if you sleep early.
+                        if (timeLeft >= 1600) {
+                            // Unlike crops and casks, this is only an approximate number of days
+                            // because of how time works while sleeping. It's close enough though.
+                            longText = LanguageKeys.Days;
+                            longTime = timeLeft / 1600;
+                            
+                            shortText = LanguageKeys.Hours;
+                            shortTime = (timeLeft % 1600);
+
+                            // Hours below 1200 are 60 minutes per hour. Overnight it's 100 minutes per hour.
+                            // We could just divide by 60 here but then you could see strange times like
+                            // "2 days, 25 hours".
+                            // This is a bit of a fudge since depending on the current time of day and when the
+                            // farmer goes to bed, the night might happen earlier or last longer, but it's just
+                            // an approximation; regardless the processing won't finish before tomorrow.
+                            if (shortTime <= 1200)
+                                shortTime /= 60;
+                            else
+                                shortTime = 20 + (shortTime - 1200) / 100;
+                        }
+
+                        if (longTime > 0)
+                            hoverText.Append(longTime).Append(" ")
                                 .Append(_helper.SafeGetString(
-                                    LanguageKeys.Hours))
+                                    longText))
                                 .Append(", ");
-                        hoverText.Append(minutes).Append(" ")
+
+                        hoverText.Append(shortTime).Append(" ")
                             .Append(_helper.SafeGetString(
-                                LanguageKeys.Minutes));
+                                shortText));
                     }
                     IClickableMenu.drawHoverText(
                         Game1.spriteBatch,


### PR DESCRIPTION
Merging rocketmantis's pull request which was submitted to the original UIInfoSuite repository.

_For processing times that are longer than 1600 minutes (1 day), the time remaining is now displayed as "X days, Y hours" instead of "Y hours, Z minutes". Notably this makes kegs, jars and tappers easier to read instead of showing hundreds of hours remaining, but it applies automatically to any long process in any big craftable._