### PR TITLE
Better weather icons

### DIFF
--- a/UIInfoSuite2/Infrastucture/Tools.cs
+++ b/UIInfoSuite2/Infrastucture/Tools.cs
@@ -3,11 +3,9 @@ using Microsoft.Xna.Framework.Graphics;
 using StardewValley;
 using StardewValley.Menus;
 using System;
-using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using StardewModdingAPI;
 
 namespace UIInfoSuite.Infrastructure
 {

--- a/UIInfoSuite2/Infrastucture/Tools.cs
+++ b/UIInfoSuite2/Infrastucture/Tools.cs
@@ -3,9 +3,11 @@ using Microsoft.Xna.Framework.Graphics;
 using StardewValley;
 using StardewValley.Menus;
 using System;
+using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using StardewModdingAPI;
 
 namespace UIInfoSuite.Infrastructure
 {
@@ -113,6 +115,42 @@ namespace UIInfoSuite.Infrastructure
             }
 
             return hoverItem;
+        }
+
+        public static void GetSubTexture(Color[] output, Color[] originalColors, Rectangle sourceBounds, Rectangle clipArea)
+        {
+            //Create output array
+            if (output.Length < clipArea.Width * clipArea.Height)
+            {
+                return;
+            }
+
+            var dest = 0;
+            for (var yOffset = 0; yOffset < clipArea.Height; yOffset++)
+            {
+                for (var xOffset = 0; xOffset < clipArea.Width; xOffset++)
+                {
+                    var idx = (clipArea.X + xOffset) + (sourceBounds.Width * (yOffset + clipArea.Y));
+                    output[dest++] = originalColors[idx];
+                }
+            }
+
+        }
+
+        public static void SetSubTexture(Color[] sourceColors, Color[] destColors, int destWidth, Rectangle destBounds)
+        {
+            if(sourceColors.Length > destColors.Length || (destBounds.Width * destBounds.Height) > destColors.Length) {
+                return;
+            }
+            var srcIdx = 0;
+            for (var yOffset = 0; yOffset < destBounds.Height; yOffset++)
+            {
+                for (var xOffset = 0; xOffset < destBounds.Width; xOffset++)
+                {
+                    var idx = (destBounds.X + xOffset) + (destWidth * (yOffset + destBounds.Y));
+                    destColors[idx] = sourceColors[srcIdx++];
+                }
+            }
         }
     }
 }

--- a/UIInfoSuite2/Infrastucture/Tools.cs
+++ b/UIInfoSuite2/Infrastucture/Tools.cs
@@ -117,7 +117,6 @@ namespace UIInfoSuite.Infrastructure
 
         public static void GetSubTexture(Color[] output, Color[] originalColors, Rectangle sourceBounds, Rectangle clipArea)
         {
-            //Create output array
             if (output.Length < clipArea.Width * clipArea.Height)
             {
                 return;

--- a/UIInfoSuite2/UIElements/ShowRainyDayIcon.cs
+++ b/UIInfoSuite2/UIElements/ShowRainyDayIcon.cs
@@ -4,10 +4,7 @@ using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Menus;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.Xna.Framework.Graphics;
 using UIInfoSuite.Infrastructure;
 using UIInfoSuite.Infrastructure.Extensions;
 
@@ -16,11 +13,17 @@ namespace UIInfoSuite.UIElements
     class ShowRainyDayIcon : IDisposable
     {
         #region Properties
+
         private bool _IsNextDayRainy;
         Rectangle? _weatherIconSpriteLocation;
         private string _hoverText;
         private ClickableTextureComponent _rainyDayIcon;
+        private Texture2D _iconSheet;
 
+        private Color[] _weatherIconColors = null;
+        private const int WeatherSheetWidth = 45;
+        private const int WeatherSheetHeight = 15;
+        
         private readonly IModHelper _helper;
         #endregion
 
@@ -28,11 +31,13 @@ namespace UIInfoSuite.UIElements
         public ShowRainyDayIcon(IModHelper helper)
         {
             _helper = helper;
+            CreateTileSheet();
         }
 
         public void Dispose()
         {
             ToggleOption(false);
+            _iconSheet.Dispose();
         }
 
         public void ToggleOption(bool showTravelingMerchant)
@@ -60,9 +65,9 @@ namespace UIInfoSuite.UIElements
                 _rainyDayIcon =
                     new ClickableTextureComponent(
                         new Rectangle(iconPosition.X, iconPosition.Y, 40, 40),
-                        Game1.animations,
+                        _iconSheet,
                         _weatherIconSpriteLocation.Value,
-                        2f);
+                        8 / 3f);
                 _rainyDayIcon.draw(Game1.spriteBatch);
             }
         }
@@ -82,8 +87,54 @@ namespace UIInfoSuite.UIElements
         #endregion
 
         #region Logic
+
+        /// <summary>
+        /// Creates a custom tilesheet for weather icons.
+        /// Meant to mimic the TV screen, which has a border around it, while the individual icons in the Cursors tilesheet don't have a border
+        /// Extracts the border, and each individual weather icon and stitches them together into one separate sheet
+        ///</summary>
+        private void CreateTileSheet()
+        {
+
+            ModEntry.MonitorObject.Log("Setting up icon sheet", LogLevel.Info);
+            // Setup Texture sheet as a copy, so as not to disturb existing sprites
+            _iconSheet = new Texture2D(Game1.graphics.GraphicsDevice , WeatherSheetWidth, WeatherSheetHeight);
+            _weatherIconColors = new Color[WeatherSheetWidth * WeatherSheetHeight];
+            var cursorColors = new Color[Game1.mouseCursors.Width * Game1.mouseCursors.Height];
+            var bounds = new Rectangle(0, 0, Game1.mouseCursors.Width, Game1.mouseCursors.Height);
+            Game1.mouseCursors.GetData(cursorColors);
+            var subTextureColors = new Color[15 * 15];
+            
+            //ModEntry.MonitorObject.Log($"Got tile sheet with length {cursorColors.Length}", LogLevel.Alert);
+            // Copy over the bits we want
+            // Border from TV screen
+            Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(499, 307, 15, 15));
+            // Copy to each destination
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(0, 0, 15, 15));
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(15, 0, 15, 15));
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(30, 0, 15, 15));
+            //ModEntry.MonitorObject.Log("Got TV textures", LogLevel.Alert);
+
+            subTextureColors = new Color[13 * 13];
+            // Rainy Weather
+            Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(504, 333, 13, 13));
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth,  new Rectangle(1, 1, 13, 13));
+            
+            // Stormy Weather
+            Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(426, 346, 13, 13));
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth,  new Rectangle(16, 1, 13, 13));
+            
+            // Snowy Weather
+            Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(465, 346, 13, 13));
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth,  new Rectangle(31, 1, 13, 13));
+            
+            //ModEntry.MonitorObject.Log("Got weather textures, setting icon sheet...", LogLevel.Alert);
+            _iconSheet.SetData(_weatherIconColors);
+        }
+
         private void GetWeatherIconSpriteLocation()
         {
+            
             switch (Game1.weatherForTomorrow)
             {
                 case Game1.weather_sunny:
@@ -95,19 +146,21 @@ namespace UIInfoSuite.UIElements
 
                 case Game1.weather_rain:
                     _IsNextDayRainy = true;
-                    _weatherIconSpriteLocation = new Rectangle(268, 1750, 20, 20);
+                    // _weatherIconSpriteLocation = new Rectangle(268, 1750, 20, 20);
+                    _weatherIconSpriteLocation = new Rectangle(0, 0, 15, 15);
                     _hoverText = _helper.SafeGetString(LanguageKeys.RainNextDay);
                     break;
 
                 case Game1.weather_lightning:
                     _IsNextDayRainy = true;
-                    _weatherIconSpriteLocation = new Rectangle(272, 1641, 20, 20);
+                    // _weatherIconSpriteLocation = new Rectangle(272, 1641, 20, 20);
+                    _weatherIconSpriteLocation = new Rectangle(15, 0, 15, 15);
                     _hoverText = _helper.SafeGetString(LanguageKeys.ThunderstormNextDay);
                     break;
 
                 case Game1.weather_snow:
                     _IsNextDayRainy = true;
-                    _weatherIconSpriteLocation = new Rectangle(260, 680, 20, 20);
+                    _weatherIconSpriteLocation = new Rectangle(30, 0, 15, 15);
                     _hoverText = _helper.SafeGetString(LanguageKeys.SnowNextDay);
                     break;
 

--- a/UIInfoSuite2/UIElements/ShowRainyDayIcon.cs
+++ b/UIInfoSuite2/UIElements/ShowRainyDayIcon.cs
@@ -105,7 +105,6 @@ namespace UIInfoSuite.UIElements
             Game1.mouseCursors.GetData(cursorColors);
             var subTextureColors = new Color[15 * 15];
             
-            //ModEntry.MonitorObject.Log($"Got tile sheet with length {cursorColors.Length}", LogLevel.Alert);
             // Copy over the bits we want
             // Border from TV screen
             Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(499, 307, 15, 15));
@@ -113,7 +112,6 @@ namespace UIInfoSuite.UIElements
             Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(0, 0, 15, 15));
             Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(15, 0, 15, 15));
             Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(30, 0, 15, 15));
-            //ModEntry.MonitorObject.Log("Got TV textures", LogLevel.Alert);
 
             subTextureColors = new Color[13 * 13];
             // Rainy Weather
@@ -128,7 +126,6 @@ namespace UIInfoSuite.UIElements
             Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(465, 346, 13, 13));
             Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth,  new Rectangle(31, 1, 13, 13));
             
-            //ModEntry.MonitorObject.Log("Got weather textures, setting icon sheet...", LogLevel.Alert);
             _iconSheet.SetData(_weatherIconColors);
         }
 
@@ -146,14 +143,12 @@ namespace UIInfoSuite.UIElements
 
                 case Game1.weather_rain:
                     _IsNextDayRainy = true;
-                    // _weatherIconSpriteLocation = new Rectangle(268, 1750, 20, 20);
                     _weatherIconSpriteLocation = new Rectangle(0, 0, 15, 15);
                     _hoverText = _helper.SafeGetString(LanguageKeys.RainNextDay);
                     break;
 
                 case Game1.weather_lightning:
                     _IsNextDayRainy = true;
-                    // _weatherIconSpriteLocation = new Rectangle(272, 1641, 20, 20);
                     _weatherIconSpriteLocation = new Rectangle(15, 0, 15, 15);
                     _hoverText = _helper.SafeGetString(LanguageKeys.ThunderstormNextDay);
                     break;


### PR DESCRIPTION
Instead of having weird cropped parts from the Animations sheet, changed the upcoming weather icons to the ones on the tv (Cursors sheet). 

I also went a bit overboard, the TV has this nice border that I wanted around the icons so I added a few methods and some logic to create a custom sheet with those parts stitched together

The TV border 
![image](https://user-images.githubusercontent.com/6218989/104866583-eae09b00-590c-11eb-986f-607b3996ba70.png)

The new icons
![image](https://user-images.githubusercontent.com/6218989/104866451-9b01d400-590c-11eb-825f-460a7fe7f412.png)

Fixes #31 
