### PR TITLE
Fix mushroom log and mossy seed effect ranges

### DIFF
--- a/UIInfoSuite2/UIElements/ShowItemEffectRanges.cs
+++ b/UIInfoSuite2/UIElements/ShowItemEffectRanges.cs
@@ -543,9 +543,9 @@ internal class ShowItemEffectRanges : IDisposable
       case ObjectsWithDistance.PrismaticSprinkler:
         return GetCircularMask(3.69, Math.Sqrt(18), false);
       case ObjectsWithDistance.MushroomLog:
-        return GetCircularMask(100, maxDisplaySquareRadius: 7);
+        return GetCircularMask(100, maxDisplaySquareRadius: 3);
       case ObjectsWithDistance.MossySeed:
-        return GetCircularMask(100, maxDisplaySquareRadius: 5);
+        return GetCircularMask(100, maxDisplaySquareRadius: 2);
       case ObjectsWithDistance.CherryBomb:
         return GetCircularMask(3.39);
       case ObjectsWithDistance.Bomb:


### PR DESCRIPTION
Mushroom log and mossy seed ranges added in b4d3a876 wrongly display quadruple (resp. double the square radius) of their actual size.

Wiki pages
https://stardewvalleywiki.com/Mushroom_Log
and
https://stardewvalleywiki.com/Moss#Moss_Growth
describe the areas as 7x7 and 5x5 respectively, so the `maxDisplaySquareRadius` value needs to be half of the area size minus one. This is also consistent with my own observation of the mushroom log behavior.