### PR TITLE
Initial Better Game Menu Support

### DIFF
--- a/UIInfoSuite2/Compatibility/ApiManager.cs
+++ b/UIInfoSuite2/Compatibility/ApiManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using StardewModdingAPI;
 
@@ -9,6 +10,7 @@ public static class ModCompat
   public const string CustomBush = "furyx639.CustomBush";
   public const string Gmcm = "spacechase0.GenericModConfigMenu";
   public const string DeluxeJournal = "MolsonCAD.DeluxeJournal";
+  public const string BetterGameMenu = "leclair.bettergamemenu";
 }
 
 public static class ApiManager
@@ -37,7 +39,17 @@ public static class ApiManager
       return null;
     }
 
-    var api = helper.ModRegistry.GetApi<T>(modId);
+    T? api;
+    try
+    {
+      // This can throw if the API cannot be mapped to type T by Pintail.
+      api = helper.ModRegistry.GetApi<T>(modId);
+    } catch (Exception ex)
+    {
+      ModEntry.MonitorObject.Log($"Could not get API for mod {modId} due to error: {ex}", LogLevel.Warn);
+      api = null;
+    }
+
     if (api is null)
     {
       if (warnIfNotPresent)

--- a/UIInfoSuite2/Compatibility/IBetterGameMenu.cs
+++ b/UIInfoSuite2/Compatibility/IBetterGameMenu.cs
@@ -16,33 +16,6 @@ namespace Leclair.Stardew.BetterGameMenu;
 
 
 /// <summary>
-/// A tab changed event is emitted whenever the currently
-/// active tab of a Better Game Menu changes.
-/// </summary>
-public interface ITabChangedEvent
-{
-
-  /// <summary>
-  /// The Better Game Menu instance involved in the event. You
-  /// can use <see cref="IBetterGameMenuApi.AsMenu(IClickableMenu)"/>
-  /// to get a more useful interface for this menu.
-  /// </summary>
-  IClickableMenu Menu { get; }
-
-  /// <summary>
-  /// The id of the tab the Game Menu was changed to.
-  /// </summary>
-  string Tab { get; }
-
-  /// <summary>
-  /// The id of the previous tab the Game Menu displayed.
-  /// </summary>
-  string OldTab { get; }
-
-}
-
-
-/// <summary>
 /// A page created event is emitted whenever a new page
 /// is created for a tab by Better Game Menu.
 /// </summary>
@@ -169,7 +142,7 @@ public interface IBetterGameMenu
 /// all the default tabs from the base game. These values are intentionally
 /// spaced out to allow for modded tabs to be inserted at specific points.
 /// </summary>
-public enum VanillaTabOrders
+public enum BetterGameMenuTabs
 {
   Inventory = 0,
   Skills = 20,
@@ -202,9 +175,7 @@ public interface IBetterGameMenuApi
   /// </summary>
   /// <param name="texture">The texture to draw from.</param>
   /// <param name="source">The source rectangle to draw.</param>
-  /// <param name="scale">The scale to draw the source at. The scale
-  /// may be reduced if necessary to contain the drawn rectangle
-  /// within the provided bounds.</param>
+  /// <param name="scale">The scale to draw the source at.</param>
   /// <param name="frames">The number of frames to draw.</param>
   /// <param name="frameTime">The amount of time each frame should be displayed.</param>
   DrawDelegate CreateDraw(Texture2D texture, Rectangle source, float scale = 1f, int frames = 1, int frameTime = 16);
@@ -218,7 +189,7 @@ public interface IBetterGameMenuApi
   /// </summary>
   /// <param name="id">The id of the tab to add.</param>
   /// <param name="order">The order of this tab relative to other tabs.
-  /// See <see cref="VanillaTabOrders"/> for an example of existing values.</param>
+  /// See <see cref="BetterGameMenuTabs"/> for an example of existing values.</param>
   /// <param name="getDisplayName">A method that returns the display name of
   /// this tab, to be displayed in a tool-tip to the user.</param>
   /// <param name="getIcon">A method that returns an icon to be displayed
@@ -278,74 +249,9 @@ public interface IBetterGameMenuApi
     Action<IClickableMenu>? onClose = null
   );
 
-  /// <summary>
-  /// Register a tab implementation for an existing tab. This can be used
-  /// to override an existing vanilla game tab.
-  /// </summary>
-  /// <param name="id">The id of the tab to register an implementation for.
-  /// The keys for the vanilla game tabs are the same as those in the
-  /// <see cref="VanillaTabOrders"/> enum.</param>
-  /// <param name="priority">The priority of this page instance provider
-  /// for this tab. When multiple page instance providers are
-  /// registered, and the user hasn't explicitly chosen one, then the
-  /// one with the highest priority is used. Please note that a given
-  /// mod can only register one provider for any given tab.</param>
-  /// <param name="getPageInstance">A method that returns a page instance
-  /// for the tab. This should never return a <c>null</c> value.</param>
-  /// <param name="getDecoration">A method that returns a decoration for
-  /// the tab UI for this tab. This can be used to, for example, add a
-  /// sparkle to a tab to indicate that new content is available. The
-  /// expected output is either <c>null</c> if no decoration should be
-  /// displayed, or a texture, rectangle, number of animation frames
-  /// to display, and delay between frame advancements. Please note that
-  /// the decoration will be automatically cleared when the user navigates
-  /// to the tab.</param>
-  /// <param name="getTabVisible">A method that returns whether or not the
-  /// tab should be visible in the menu. This is called whenever a menu is
-  /// opened, as well as when <see cref="IBetterGameMenu.UpdateTabs(string?)"/>
-  /// is called.</param>
-  /// <param name="getMenuInvisible">A method that returns the value that the
-  /// game menu should set its <see cref="IBetterGameMenu.Invisible"/> flag
-  /// to when this is the active tab.</param>
-  /// <param name="getWidth">A method that returns a specific width to use when
-  /// rendering this tab, in case the page instance requires a different width
-  /// than the standard value.</param>
-  /// <param name="getHeight">A method that returns a specific height to use
-  /// when rendering this tab, in case the page instance requires a different
-  /// height than the standard value.</param>
-  /// <param name="onResize">A method that is called when the game window is
-  /// resized, in addition to the standard <see cref="IClickableMenu.gameWindowSizeChanged(Rectangle, Rectangle)"/>.
-  /// This can be used to recreate a menu page if necessary by returning a
-  /// new <see cref="IClickableMenu"/> instance. Several menus in the vanilla
-  /// game use this logic.</param>
-  /// <param name="onClose">A method that is called whenever a page instance
-  /// is cleaned up. The standard Game Menu doesn't call <see cref="IClickableMenu.cleanupBeforeExit"/>
-  /// of its pages, and only calls <see cref="IClickableMenu.emergencyShutDown"/>
-  /// of the currently active tab, and we're keeping that behavior for
-  /// compatibility. This method will always be called. This includes calling
-  /// it for menus that were replaced by the <c>onResize</c> method.</param>
-  void RegisterImplementation(
-    string id,
-    int priority,
-    Func<IClickableMenu, IClickableMenu> getPageInstance,
-    Func<DrawDelegate?>? getDecoration = null,
-    Func<bool>? getTabVisible = null,
-    Func<bool>? getMenuInvisible = null,
-    Func<int, int>? getWidth = null,
-    Func<int, int>? getHeight = null,
-    Func<(IClickableMenu Menu, IClickableMenu OldPage), IClickableMenu?>? onResize = null,
-    Action<IClickableMenu>? onClose = null
-  );
-
   #endregion
 
   #region Menu Class Access
-
-  /// <summary>
-  /// Return the Better Game Menu menu implementation's type, in case
-  /// you want to do spooky stuff to it, I guess.
-  /// </summary>
-  Type GetMenuType();
 
   /// <summary>
   /// The active screen's current Better Game Menu, if one is open,
@@ -361,51 +267,11 @@ public interface IBetterGameMenuApi
   /// <param name="menu">The menu to attempt to cast</param>
   IBetterGameMenu? AsMenu(IClickableMenu menu);
 
-  /// <summary>
-  /// Attempt to open a Better Game Menu. This will only work if a game menu can
-  /// be opened for the active screen.
-  /// </summary>
-  /// <param name="defaultTab">The tab that the menu should be opened to.</param>
-  /// <param name="playSound">Whether or not a sound should play when the menu is opened.</param>
-  /// <param name="closeExistingMenu">If true, attempt to close the <see cref="Game1.activeClickableMenu"/>
-  /// if one is set to make room for the game menu.</param>
-  /// <returns>The menu that was opened, if one was.</returns>
-  IBetterGameMenu? TryOpenMenu(
-    string? defaultTab = null,
-    bool playSound = false,
-    bool closeExistingMenu = false
-  );
-
   #endregion
 
   #region Menu Events
 
-  public delegate void MenuCreatedDelegate(IClickableMenu menu);
-  public delegate void TabChangedDelegate(ITabChangedEvent evt);
   public delegate void PageCreatedDelegate(IPageCreatedEvent evt);
-
-  /// <summary>
-  /// This event fires whenever the game menu is created, at the end of
-  /// the menu's constructor. As such, this is called before the new <see cref="IBetterGameMenu"/>
-  /// instance is assigned to <see cref="Game1.activeClickableMenu"/>.
-  /// </summary>
-  void OnMenuCreated(MenuCreatedDelegate handler, EventPriority priority = EventPriority.Normal);
-
-  /// <summary>
-  /// Unregister a handler for the MenuCreated event.
-  /// </summary>
-  void OffMenuCreated(MenuCreatedDelegate handler);
-
-  /// <summary>
-  /// This event fires whenever the current tab changes, except when a
-  /// game menu is first created.
-  /// </summary>
-  void OnTabChanged(TabChangedDelegate handler, EventPriority priority = EventPriority.Normal);
-
-  /// <summary>
-  /// Unregister a handler for the TabChanged event.
-  /// </summary>
-  void OffTabChanged(TabChangedDelegate handler);
 
   /// <summary>
   /// This event fires whenever a new page instance is created. This can happen

--- a/UIInfoSuite2/Compatibility/IBetterGameMenu.cs
+++ b/UIInfoSuite2/Compatibility/IBetterGameMenu.cs
@@ -1,0 +1,427 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using StardewModdingAPI.Events;
+
+using StardewValley;
+using StardewValley.Menus;
+
+namespace Leclair.Stardew.BetterGameMenu;
+
+
+/// <summary>
+/// A tab changed event is emitted whenever the currently
+/// active tab of a Better Game Menu changes.
+/// </summary>
+public interface ITabChangedEvent
+{
+
+  /// <summary>
+  /// The Better Game Menu instance involved in the event. You
+  /// can use <see cref="IBetterGameMenuApi.AsMenu(IClickableMenu)"/>
+  /// to get a more useful interface for this menu.
+  /// </summary>
+  IClickableMenu Menu { get; }
+
+  /// <summary>
+  /// The id of the tab the Game Menu was changed to.
+  /// </summary>
+  string Tab { get; }
+
+  /// <summary>
+  /// The id of the previous tab the Game Menu displayed.
+  /// </summary>
+  string OldTab { get; }
+
+}
+
+
+/// <summary>
+/// A page created event is emitted whenever a new page
+/// is created for a tab by Better Game Menu.
+/// </summary>
+public interface IPageCreatedEvent
+{
+
+  /// <summary>
+  /// The Better Game Menu instance involved in the event. You
+  /// can use <see cref="IBetterGameMenuApi.AsMenu(IClickableMenu)"/>
+  /// to get a more useful interface for this menu.
+  /// </summary>
+  IClickableMenu Menu { get; }
+
+  /// <summary>
+  /// The id of the tab the page was created for.
+  /// </summary>
+  string Tab { get; }
+
+  /// <summary>
+  /// The id of the provider the page was created with.
+  /// </summary>
+  string Source { get; }
+
+  /// <summary>
+  /// The new page that was just created.
+  /// </summary>
+  IClickableMenu Page { get; }
+
+  /// <summary>
+  /// If the page was previously created and is being replaced,
+  /// this will be the old page instance. Otherwise, this will
+  /// be <c>null</c>.
+  /// </summary>
+  IClickableMenu? OldPage { get; }
+
+}
+
+
+/// <summary>
+/// This interface represents a Better Game Menu. 
+/// </summary>
+public interface IBetterGameMenu
+{
+  /// <summary>
+  /// The <see cref="IClickableMenu"/> instance for this game menu. This is
+  /// the same object, but with a different type. This property is included
+  /// for convenience due to how API proxying works.
+  /// </summary>
+  IClickableMenu Menu { get; }
+
+  /// <summary>
+  /// Whether or not the menu is currently drawing itself. This is typically
+  /// always <c>false</c> except when viewing the <c>Map</c> tab.
+  /// </summary>
+  bool Invisible { get; set; }
+
+  /// <summary>
+  /// A list of ids of the currently visible tabs.
+  /// </summary>
+  IReadOnlyList<string> VisibleTabs { get; }
+
+  /// <summary>
+  /// The id of the currently active tab.
+  /// </summary>
+  string CurrentTab { get; }
+
+  /// <summary>
+  /// The <see cref="IClickableMenu"/> instance for the currently active tab.
+  /// This may be <c>null</c> if the page instance for the currently active
+  /// tab is still being initialized.
+  /// </summary>
+  IClickableMenu? CurrentPage { get; }
+
+  /// <summary>
+  /// Whether or not the currently displayed page is an error page. Error
+  /// pages are used when a tab implementation's GetPageInstance method
+  /// throws an exception.
+  /// </summary>
+  bool CurrentTabHasErrored { get; }
+
+  /// <summary>
+  /// Try to get the source for the specific tab.
+  /// </summary>
+  /// <param name="target">The id of the tab to get the source of.</param>
+  /// <param name="source">The unique ID of the mod that registered the
+  /// implementation being used, or <c>stardew</c> if the base game's
+  /// implementation is being used.</param>
+  /// <returns>Whether or not the tab is registered with the system.</returns>
+  bool TryGetSource(string target, [NotNullWhen(true)] out string? source);
+
+  /// <summary>
+  /// Try to get the <see cref="IClickableMenu"/> instance for a specific tab.
+  /// </summary>
+  /// <param name="target">The id of the tab to get the page for.</param>
+  /// <param name="page">The page instance, if one exists.</param>
+  /// <param name="forceCreation">If set to true, an instance will attempt to
+  /// be created if one has not already been created.</param>
+  /// <returns>Whether or not a page instance for that tab exists.</returns>
+  bool TryGetPage(string target, [NotNullWhen(true)] out IClickableMenu? page, bool forceCreation = false);
+
+  /// <summary>
+  /// Attempt to change the currently active tab to the target tab.
+  /// </summary>
+  /// <param name="target">The id of the tab to change to.</param>
+  /// <param name="playSound">Whether or not to play a sound.</param>
+  /// <returns>Whether or not the tab was changed successfully.</returns>
+  bool TryChangeTab(string target, bool playSound = true);
+
+  /// <summary>
+  /// Force the menu to recalculate the visible tabs. This will not recreate
+  /// <see cref="IClickableMenu"/> instances, but can be used to cause an
+  /// inactive tab to be removed, or a previously hidden tab to be added.
+  /// This can also be used to update tab decorations if necessary.
+  /// </summary>
+  /// <param name="target">Optionally, a specific tab to update rather than
+  /// updating all tabs.</param>
+  void UpdateTabs(string? target = null);
+
+}
+
+
+/// <summary>
+/// This enum is included for reference and has the order value for
+/// all the default tabs from the base game. These values are intentionally
+/// spaced out to allow for modded tabs to be inserted at specific points.
+/// </summary>
+public enum VanillaTabOrders
+{
+  Inventory = 0,
+  Skills = 20,
+  Social = 40,
+  Map = 60,
+  Crafting = 80,
+  Animals = 100,
+  Powers = 120,
+  Collections = 140,
+  Options = 160,
+  Exit = 200
+}
+
+
+public interface IBetterGameMenuApi
+{
+
+  /// <summary>
+  /// A delegate for drawing something onto the screen.
+  /// </summary>
+  /// <param name="batch">The <see cref="SpriteBatch"/> to draw with.</param>
+  /// <param name="bounds">The region where the thing should be drawn.</param>
+  public delegate void DrawDelegate(SpriteBatch batch, Rectangle bounds);
+
+  #region Helpers
+
+  /// <summary>
+  /// Create a draw delegate that draws the provided texture to the
+  /// screen. This supports basic animations if required.
+  /// </summary>
+  /// <param name="texture">The texture to draw from.</param>
+  /// <param name="source">The source rectangle to draw.</param>
+  /// <param name="scale">The scale to draw the source at. The scale
+  /// may be reduced if necessary to contain the drawn rectangle
+  /// within the provided bounds.</param>
+  /// <param name="frames">The number of frames to draw.</param>
+  /// <param name="frameTime">The amount of time each frame should be displayed.</param>
+  DrawDelegate CreateDraw(Texture2D texture, Rectangle source, float scale = 1f, int frames = 1, int frameTime = 16);
+
+  #endregion
+
+  #region Tab Registration
+
+  /// <summary>
+  /// Register a new tab with the system. 
+  /// </summary>
+  /// <param name="id">The id of the tab to add.</param>
+  /// <param name="order">The order of this tab relative to other tabs.
+  /// See <see cref="VanillaTabOrders"/> for an example of existing values.</param>
+  /// <param name="getDisplayName">A method that returns the display name of
+  /// this tab, to be displayed in a tool-tip to the user.</param>
+  /// <param name="getIcon">A method that returns an icon to be displayed
+  /// on the tab UI for this tab, expecting both a texture and a Rectangle.</param>
+  /// <param name="priority">The priority of the default page instance
+  /// provider for this tab. When multiple page instance providers are
+  /// registered, and the user hasn't explicitly chosen one, then the
+  /// one with the highest priority is used. Please note that a given
+  /// mod can only register one provider for any given tab.</param>
+  /// <param name="getPageInstance">A method that returns a page instance
+  /// for the tab. This should never return a <c>null</c> value.</param>
+  /// <param name="getDecoration">A method that returns a decoration for
+  /// the tab UI for this tab. This can be used to, for example, add a
+  /// sparkle to a tab to indicate that new content is available. The
+  /// expected output is either <c>null</c> if no decoration should be
+  /// displayed, or a texture, rectangle, number of animation frames
+  /// to display, and delay between frame advancements. Please note that
+  /// the decoration will be automatically cleared when the user navigates
+  /// to the tab.</param>
+  /// <param name="getTabVisible">A method that returns whether or not the
+  /// tab should be visible in the menu. This is called whenever a menu is
+  /// opened, as well as when <see cref="IBetterGameMenu.UpdateTabs(string?)"/>
+  /// is called.</param>
+  /// <param name="getMenuInvisible">A method that returns the value that the
+  /// game menu should set its <see cref="IBetterGameMenu.Invisible"/> flag
+  /// to when this is the active tab.</param>
+  /// <param name="getWidth">A method that returns a specific width to use when
+  /// rendering this tab, in case the page instance requires a different width
+  /// than the standard value.</param>
+  /// <param name="getHeight">A method that returns a specific height to use
+  /// when rendering this tab, in case the page instance requires a different
+  /// height than the standard value.</param>
+  /// <param name="onResize">A method that is called when the game window is
+  /// resized, in addition to the standard <see cref="IClickableMenu.gameWindowSizeChanged(Rectangle, Rectangle)"/>.
+  /// This can be used to recreate a menu page if necessary by returning a
+  /// new <see cref="IClickableMenu"/> instance. Several menus in the vanilla
+  /// game use this logic.</param>
+  /// <param name="onClose">A method that is called whenever a page instance
+  /// is cleaned up. The standard Game Menu doesn't call <see cref="IClickableMenu.cleanupBeforeExit"/>
+  /// of its pages, and only calls <see cref="IClickableMenu.emergencyShutDown"/>
+  /// of the currently active tab, and we're keeping that behavior for
+  /// compatibility. This method will always be called. This includes calling
+  /// it for menus that were replaced by the <c>onResize</c> method.</param>
+  void RegisterTab(
+    string id,
+    int order,
+    Func<string> getDisplayName,
+    Func<(DrawDelegate DrawMethod, bool DrawBackground)> getIcon,
+    int priority,
+    Func<IClickableMenu, IClickableMenu> getPageInstance,
+    Func<DrawDelegate?>? getDecoration = null,
+    Func<bool>? getTabVisible = null,
+    Func<bool>? getMenuInvisible = null,
+    Func<int, int>? getWidth = null,
+    Func<int, int>? getHeight = null,
+    Func<(IClickableMenu Menu, IClickableMenu OldPage), IClickableMenu?>? onResize = null,
+    Action<IClickableMenu>? onClose = null
+  );
+
+  /// <summary>
+  /// Register a tab implementation for an existing tab. This can be used
+  /// to override an existing vanilla game tab.
+  /// </summary>
+  /// <param name="id">The id of the tab to register an implementation for.
+  /// The keys for the vanilla game tabs are the same as those in the
+  /// <see cref="VanillaTabOrders"/> enum.</param>
+  /// <param name="priority">The priority of this page instance provider
+  /// for this tab. When multiple page instance providers are
+  /// registered, and the user hasn't explicitly chosen one, then the
+  /// one with the highest priority is used. Please note that a given
+  /// mod can only register one provider for any given tab.</param>
+  /// <param name="getPageInstance">A method that returns a page instance
+  /// for the tab. This should never return a <c>null</c> value.</param>
+  /// <param name="getDecoration">A method that returns a decoration for
+  /// the tab UI for this tab. This can be used to, for example, add a
+  /// sparkle to a tab to indicate that new content is available. The
+  /// expected output is either <c>null</c> if no decoration should be
+  /// displayed, or a texture, rectangle, number of animation frames
+  /// to display, and delay between frame advancements. Please note that
+  /// the decoration will be automatically cleared when the user navigates
+  /// to the tab.</param>
+  /// <param name="getTabVisible">A method that returns whether or not the
+  /// tab should be visible in the menu. This is called whenever a menu is
+  /// opened, as well as when <see cref="IBetterGameMenu.UpdateTabs(string?)"/>
+  /// is called.</param>
+  /// <param name="getMenuInvisible">A method that returns the value that the
+  /// game menu should set its <see cref="IBetterGameMenu.Invisible"/> flag
+  /// to when this is the active tab.</param>
+  /// <param name="getWidth">A method that returns a specific width to use when
+  /// rendering this tab, in case the page instance requires a different width
+  /// than the standard value.</param>
+  /// <param name="getHeight">A method that returns a specific height to use
+  /// when rendering this tab, in case the page instance requires a different
+  /// height than the standard value.</param>
+  /// <param name="onResize">A method that is called when the game window is
+  /// resized, in addition to the standard <see cref="IClickableMenu.gameWindowSizeChanged(Rectangle, Rectangle)"/>.
+  /// This can be used to recreate a menu page if necessary by returning a
+  /// new <see cref="IClickableMenu"/> instance. Several menus in the vanilla
+  /// game use this logic.</param>
+  /// <param name="onClose">A method that is called whenever a page instance
+  /// is cleaned up. The standard Game Menu doesn't call <see cref="IClickableMenu.cleanupBeforeExit"/>
+  /// of its pages, and only calls <see cref="IClickableMenu.emergencyShutDown"/>
+  /// of the currently active tab, and we're keeping that behavior for
+  /// compatibility. This method will always be called. This includes calling
+  /// it for menus that were replaced by the <c>onResize</c> method.</param>
+  void RegisterImplementation(
+    string id,
+    int priority,
+    Func<IClickableMenu, IClickableMenu> getPageInstance,
+    Func<DrawDelegate?>? getDecoration = null,
+    Func<bool>? getTabVisible = null,
+    Func<bool>? getMenuInvisible = null,
+    Func<int, int>? getWidth = null,
+    Func<int, int>? getHeight = null,
+    Func<(IClickableMenu Menu, IClickableMenu OldPage), IClickableMenu?>? onResize = null,
+    Action<IClickableMenu>? onClose = null
+  );
+
+  #endregion
+
+  #region Menu Class Access
+
+  /// <summary>
+  /// Return the Better Game Menu menu implementation's type, in case
+  /// you want to do spooky stuff to it, I guess.
+  /// </summary>
+  Type GetMenuType();
+
+  /// <summary>
+  /// The active screen's current Better Game Menu, if one is open,
+  /// else <c>null</c>.
+  /// </summary>
+  IBetterGameMenu? ActiveMenu { get; }
+
+  /// <summary>
+  /// Attempt to cast the provided menu into an <see cref="IBetterGameMenu"/>.
+  /// This can be useful if you're working with a menu that isn't currently
+  /// assigned to <see cref="Game1.activeClickableMenu"/>.
+  /// </summary>
+  /// <param name="menu">The menu to attempt to cast</param>
+  IBetterGameMenu? AsMenu(IClickableMenu menu);
+
+  /// <summary>
+  /// Attempt to open a Better Game Menu. This will only work if a game menu can
+  /// be opened for the active screen.
+  /// </summary>
+  /// <param name="defaultTab">The tab that the menu should be opened to.</param>
+  /// <param name="playSound">Whether or not a sound should play when the menu is opened.</param>
+  /// <param name="closeExistingMenu">If true, attempt to close the <see cref="Game1.activeClickableMenu"/>
+  /// if one is set to make room for the game menu.</param>
+  /// <returns>The menu that was opened, if one was.</returns>
+  IBetterGameMenu? TryOpenMenu(
+    string? defaultTab = null,
+    bool playSound = false,
+    bool closeExistingMenu = false
+  );
+
+  #endregion
+
+  #region Menu Events
+
+  public delegate void MenuCreatedDelegate(IClickableMenu menu);
+  public delegate void TabChangedDelegate(ITabChangedEvent evt);
+  public delegate void PageCreatedDelegate(IPageCreatedEvent evt);
+
+  /// <summary>
+  /// This event fires whenever the game menu is created, at the end of
+  /// the menu's constructor. As such, this is called before the new <see cref="IBetterGameMenu"/>
+  /// instance is assigned to <see cref="Game1.activeClickableMenu"/>.
+  /// </summary>
+  void OnMenuCreated(MenuCreatedDelegate handler, EventPriority priority = EventPriority.Normal);
+
+  /// <summary>
+  /// Unregister a handler for the MenuCreated event.
+  /// </summary>
+  void OffMenuCreated(MenuCreatedDelegate handler);
+
+  /// <summary>
+  /// This event fires whenever the current tab changes, except when a
+  /// game menu is first created.
+  /// </summary>
+  void OnTabChanged(TabChangedDelegate handler, EventPriority priority = EventPriority.Normal);
+
+  /// <summary>
+  /// Unregister a handler for the TabChanged event.
+  /// </summary>
+  void OffTabChanged(TabChangedDelegate handler);
+
+  /// <summary>
+  /// This event fires whenever a new page instance is created. This can happen
+  /// the first time a page is accessed, whenever something calls
+  /// <see cref="TryGetPage(string, out IClickableMenu?, bool)"/> with the
+  /// <c>forceCreation</c> flag set to true, or when the menu has been resized
+  /// and the tab implementation's <c>OnResize</c> method returned a new
+  /// page instance.
+  /// </summary>
+  void OnPageCreated(PageCreatedDelegate handler, EventPriority priority = EventPriority.Normal);
+
+  /// <summary>
+  /// Unregister a handler for the PageCreated event.
+  /// </summary>
+  void OffPageCreated(PageCreatedDelegate handler);
+
+  #endregion
+
+}

--- a/UIInfoSuite2/Infrastructure/Tools.cs
+++ b/UIInfoSuite2/Infrastructure/Tools.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using Leclair.Stardew.BetterGameMenu;
+
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewValley;
@@ -10,6 +13,9 @@ using StardewValley.GameData.FruitTrees;
 using StardewValley.Menus;
 using StardewValley.TerrainFeatures;
 using StardewValley.WorldMaps;
+
+using UIInfoSuite2.Compatibility;
+
 using SObject = StardewValley.Object;
 
 namespace UIInfoSuite2.Infrastructure;
@@ -87,6 +93,24 @@ public static class Tools
     }
   }
 
+  public static IClickableMenu? GetCurrentMenuPage()
+  {
+    if (Game1.activeClickableMenu is GameMenu gameMenu)
+    {
+      return gameMenu.GetCurrentPage();
+    }
+    if (ApiManager.GetApi<IBetterGameMenuApi>(ModCompat.BetterGameMenu, out var bgm))
+    {
+      return bgm.ActiveMenu?.CurrentPage;
+    }
+    return null;
+  }
+
+  public static bool IsGameMenuOpen()
+  {
+    return Game1.activeClickableMenu is GameMenu || (ApiManager.GetApi<IBetterGameMenuApi>(ModCompat.BetterGameMenu, out var bgm) && bgm.ActiveMenu != null);
+  }
+
   public static Item? GetHoveredItem()
   {
     Item? hoverItem = null;
@@ -96,9 +120,14 @@ public static class Tools
       hoverItem = Game1.onScreenMenus.OfType<Toolbar>().Select(tb => tb.hoverItem).FirstOrDefault(hi => hi is not null);
     }
 
-    if (Game1.activeClickableMenu is GameMenu gameMenu && gameMenu.GetCurrentPage() is InventoryPage inventory)
+    if (GetCurrentMenuPage() is InventoryPage inventory)
     {
       hoverItem = inventory.hoveredItem;
+    }
+
+    if (GetCurrentMenuPage() is CraftingPage crafting)
+    {
+      hoverItem = crafting.hoverItem;
     }
 
     if (Game1.activeClickableMenu is ItemGrabMenu itemMenu)

--- a/UIInfoSuite2/Infrastructure/Tools.cs
+++ b/UIInfoSuite2/Infrastructure/Tools.cs
@@ -114,23 +114,21 @@ public static class Tools
   public static Item? GetHoveredItem()
   {
     Item? hoverItem = null;
+    var page = GetCurrentMenuPage();
 
     if (Game1.activeClickableMenu == null && Game1.onScreenMenus != null)
     {
       hoverItem = Game1.onScreenMenus.OfType<Toolbar>().Select(tb => tb.hoverItem).FirstOrDefault(hi => hi is not null);
     }
-
-    if (GetCurrentMenuPage() is InventoryPage inventory)
+    else if (page is InventoryPage inventory)
     {
       hoverItem = inventory.hoveredItem;
     }
-
-    if (GetCurrentMenuPage() is CraftingPage crafting)
+    else if (page is CraftingPage crafting)
     {
       hoverItem = crafting.hoverItem;
     }
-
-    if (Game1.activeClickableMenu is ItemGrabMenu itemMenu)
+    else if (Game1.activeClickableMenu is ItemGrabMenu itemMenu)
     {
       hoverItem = itemMenu.hoveredItem;
     }

--- a/UIInfoSuite2/ModEntry.cs
+++ b/UIInfoSuite2/ModEntry.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+
+using Leclair.Stardew.BetterGameMenu;
+
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
@@ -53,6 +56,7 @@ public class ModEntry : Mod
     // get Generic Mod Config Menu's API (if it's installed)
     var configMenu = ApiManager.TryRegisterApi<IGenericModConfigMenuApi>(Helper, ModCompat.Gmcm, "1.6.0");
     ApiManager.TryRegisterApi<ICustomBushApi>(Helper, ModCompat.CustomBush, "1.2.1", true);
+    ApiManager.TryRegisterApi<IBetterGameMenuApi>(Helper, ModCompat.BetterGameMenu, "0.1.0");
 
     if (configMenu is null)
     {

--- a/UIInfoSuite2/Options/ModOptionsPageHandler.cs
+++ b/UIInfoSuite2/Options/ModOptionsPageHandler.cs
@@ -1,12 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+
+using Leclair.Stardew.BetterGameMenu;
+
 using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Menus;
+
+using UIInfoSuite2.Compatibility;
 using UIInfoSuite2.Infrastructure;
 using UIInfoSuite2.Infrastructure.Extensions;
 using UIInfoSuite2.UIElements;
@@ -453,6 +458,11 @@ internal class ModOptionsPageHandler : IDisposable
         $"{GetType().Name}: Our tab was added back as the final step of the window resize workaround"
       );
     }
+  }
+
+  internal ModOptionsPage GetMenuInstance()
+  {
+    return new ModOptionsPage(_optionsElements, _helper.Events);
   }
 
   private void OnUpdateTicked(object? sender, EventArgs e)

--- a/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
+++ b/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
@@ -157,7 +157,7 @@ internal class LocationOfTownsfolk : IDisposable
 
     if (ApiManager.GetApi<IBetterGameMenuApi>(ModCompat.BetterGameMenu, out var bgm) &&
         bgm.ActiveMenu != null &&
-        bgm.ActiveMenu.TryGetPage(nameof(VanillaTabOrders.Social), out var sp)
+        bgm.ActiveMenu.TryGetPage(nameof(BetterGameMenuTabs.Social), out var sp)
     )
       return sp as SocialPage;
 

--- a/UIInfoSuite2/UIElements/ShowAccurateHearts.cs
+++ b/UIInfoSuite2/UIElements/ShowAccurateHearts.cs
@@ -1,19 +1,24 @@
 ﻿using System;
+
+using Leclair.Stardew.BetterGameMenu;
+
 using Microsoft.Xna.Framework;
 using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Menus;
+
+using UIInfoSuite2.Compatibility;
+using UIInfoSuite2.Infrastructure;
 
 namespace UIInfoSuite2.UIElements;
 
 internal class ShowAccurateHearts : IDisposable
 {
 #region Properties
-  private SocialPage? _socialPage;
   private readonly IModEvents _events;
 
     // @formatter:off
-    private readonly int[][] _numArray =
+    private static readonly int[][] _numArray =
     {
       new[] { 1, 1, 0, 1, 1 },
       new[] { 1, 1, 1, 1, 1 },
@@ -36,69 +41,46 @@ internal class ShowAccurateHearts : IDisposable
 
   public void ToggleOption(bool showAccurateHearts)
   {
-    _events.Display.MenuChanged -= OnMenuChanged;
     _events.Display.RenderedActiveMenu -= OnRenderedActiveMenu;
 
     if (showAccurateHearts)
     {
-      _events.Display.MenuChanged += OnMenuChanged;
       _events.Display.RenderedActiveMenu += OnRenderedActiveMenu;
     }
   }
 #endregion
 
 #region Event subscriptions
-  private void OnRenderedActiveMenu(object sender, RenderedActiveMenuEventArgs e)
+  private void OnRenderedActiveMenu(object? sender, RenderedActiveMenuEventArgs e)
   {
-    if (_socialPage == null)
+    if (Tools.GetCurrentMenuPage() is not SocialPage socialPage)
     {
-      GetSocialPage();
       return;
     }
 
-    if (Game1.activeClickableMenu is GameMenu gameMenu && gameMenu.currentTab == 2)
-    {
-      DrawHeartFills();
+    DrawHeartFills(socialPage);
 
+    if (Game1.activeClickableMenu is GameMenu gameMenu)
+    {
       string hoverText = gameMenu.hoverText;
       IClickableMenu.drawHoverText(Game1.spriteBatch, hoverText, Game1.smallFont);
     }
   }
-
-  private void OnMenuChanged(object sender, MenuChangedEventArgs e)
-  {
-    GetSocialPage();
-  }
 #endregion
 
 #region Logic
-  private void GetSocialPage()
+  private static void DrawHeartFills(SocialPage? socialPage)
   {
-    if (Game1.activeClickableMenu is GameMenu gameMenu)
-    {
-      foreach (IClickableMenu? menu in gameMenu.pages)
-      {
-        if (menu is SocialPage page)
-        {
-          _socialPage = page;
-          break;
-        }
-      }
-    }
-  }
-
-  private void DrawHeartFills()
-  {
-    if (_socialPage == null)
+    if (socialPage == null)
     {
       return;
     }
 
-    var yOffset = 0;
+    int yOffset = 0;
 
-    for (int i = _socialPage.slotPosition; i < _socialPage.slotPosition + 5 && i < _socialPage.SocialEntries.Count; ++i)
+    for (int i = socialPage.slotPosition; i < socialPage.slotPosition + 5 && i < socialPage.SocialEntries.Count; ++i)
     {
-      string internalName = _socialPage.SocialEntries[i].InternalName;
+      string internalName = socialPage.SocialEntries[i].InternalName;
       if (Game1.player.friendshipData.TryGetValue(internalName, out Friendship friendshipValues) &&
           friendshipValues.Points > 0 &&
           friendshipValues.Points <
@@ -114,9 +96,9 @@ internal class ShowAccurateHearts : IDisposable
     }
   }
 
-  private void DrawEachIndividualSquare(int friendshipLevel, int friendshipPoints, int yPosition)
+  private static void DrawEachIndividualSquare(int friendshipLevel, int friendshipPoints, int yPosition)
   {
-    var numberOfPointsToDraw = (int)(friendshipPoints / 12.5);
+    int numberOfPointsToDraw = (int)(friendshipPoints / 12.5);
     int num2;
 
     if (friendshipLevel >= 10)
@@ -129,9 +111,9 @@ internal class ShowAccurateHearts : IDisposable
       num2 = 32 * friendshipLevel;
     }
 
-    for (var i = 3; i >= 0 && numberOfPointsToDraw > 0; --i)
+    for (int i = 3; i >= 0 && numberOfPointsToDraw > 0; --i)
     {
-      for (var j = 0; j < 5 && numberOfPointsToDraw > 0; ++j, --numberOfPointsToDraw)
+      for (int j = 0; j < 5 && numberOfPointsToDraw > 0; ++j, --numberOfPointsToDraw)
       {
         if (_numArray[i][j] == 1)
         {

--- a/UIInfoSuite2/UIElements/ShowCalendarAndBillboardOnGameMenuButton.cs
+++ b/UIInfoSuite2/UIElements/ShowCalendarAndBillboardOnGameMenuButton.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+
+using Leclair.Stardew.BetterGameMenu;
+
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
@@ -8,6 +11,8 @@ using StardewModdingAPI.Events;
 using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Menus;
+
+using UIInfoSuite2.Compatibility;
 using UIInfoSuite2.Infrastructure;
 
 namespace UIInfoSuite2.UIElements;
@@ -56,28 +61,18 @@ internal class ShowCalendarAndBillboardOnGameMenuButton : IDisposable
       _helper.Events.GameLoop.UpdateTicked += OnUpdateTicked;
     }
   }
-#endregion
+  #endregion
 
-
-#region Event subscriptions
-  private void OnUpdateTicked(object sender, EventArgs e)
+  #region Event subscriptions
+  private void OnUpdateTicked(object? sender, EventArgs e)
   {
     // Get hovered and hold item
     _hoverItem.Value = Tools.GetHoveredItem();
-    if (Game1.activeClickableMenu is not GameMenu gameMenu)
-    {
-      return;
-    }
-
-    List<IClickableMenu> menuList = gameMenu.pages;
-
-    if (menuList[0] is InventoryPage)
-    {
+    if (Tools.GetCurrentMenuPage() is InventoryPage)
       _heldItem.Value = Game1.player.CursorSlotItem;
-    }
   }
 
-  private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
+  private void OnButtonPressed(object? sender, ButtonPressedEventArgs e)
   {
     if (e.Button == SButton.MouseLeft)
     {
@@ -89,13 +84,12 @@ internal class ShowCalendarAndBillboardOnGameMenuButton : IDisposable
     }
   }
 
-  private void OnRenderedActiveMenu(object sender, EventArgs e)
+  private void OnRenderedActiveMenu(object? sender, EventArgs e)
   {
     if (_hoverItem.Value == null &&
-        Game1.activeClickableMenu is GameMenu gameMenu &&
-        gameMenu.currentTab == 0 &&
+        Tools.GetCurrentMenuPage() is InventoryPage &&
         _heldItem.Value == null &&
-        gameMenu.GetChildMenu() == null)
+        Game1.activeClickableMenu.GetChildMenu() == null)
     {
       DrawBillboard();
     }
@@ -131,8 +125,7 @@ internal class ShowCalendarAndBillboardOnGameMenuButton : IDisposable
 
   private void ActivateBillboard()
   {
-    if (Game1.activeClickableMenu is GameMenu gameMenu &&
-        gameMenu.currentTab == 0 &&
+    if (Tools.GetCurrentMenuPage() is InventoryPage &&
         _heldItem.Value == null &&
         _showBillboardButton.Value.containsPoint(
           (int)Utility.ModifyCoordinateForUIScale(Game1.getMouseX()),


### PR DESCRIPTION
Hello!

[Better Game Menu](https://github.com/KhloeLeclair/StardewMods/releases/tag/BetterGameMenu-Preview2) is a new mod I'm going to be releasing that replaces `GameMenu` with a replacement that:

1. Is considerably more efficient by virtue of only creating page instances when the pages are actually accessed.
2. Has a robust API to let other mods work with the game menu, making it easy to register new tabs, override existing tabs, and respond to events involving the menu.

I realize this has the potential to break a lot of things, so I'm going to be submitting PRs to various mods that interact with GameMenu to implement support for BetterGameMenu. This is such a PR.

---

For UI Info Suite 2 specifically, my PR here makes the following features work:

1. Show Accurate Hearts
2. Show Today's Gifts
3. Show Calendar and Billboard on Game Menu
4. Location of Townsfolk
5. Displaying the options tab in the game menu.

I did a bit of refactoring on the first couple to remove cached references to menu pages that are easy and efficient to grab references too. For the Calendar/Billboard I didn't refactor how you're storing the current hover/held item, but I did mess with the logic a little so it only considers the currently active menu page.

I also added a helper method that gets the currently active menu page, whether from GameMenu or BetterGameMenu.

Update: As of now, this PR also adds the options tab to Better Game Menu. It was easier than I thought at first glance.

Anyways, I hope you find this helpful! If you need more assistance, have questions, etc. please let me know! Feel free to ping me in Discord or just reply here.